### PR TITLE
add .encode to strings in hash call

### DIFF
--- a/app.py
+++ b/app.py
@@ -138,8 +138,8 @@ def generate_token():
     rand = random.SystemRandom()
     random_string = ''.join(rand.choice(chars) for _ in range(40))
     return hmac.new(
-        config.SECRET_KEY,
-        random_string,
+        config.SECRET_KEY.encode('utf-8'),
+        random_string.encode('utf-8'),
         hashlib.sha256
     ).hexdigest()
 


### PR DESCRIPTION
python 3 needs strings encoded before hashing.
have not checked in python 2 but .encode exists for strings